### PR TITLE
Added language support for lol_us, en_ud, en_pt, and enws

### DIFF
--- a/src/main/resources/assets/playercontainer/lang/en_pt.json
+++ b/src/main/resources/assets/playercontainer/lang/en_pt.json
@@ -1,0 +1,25 @@
+{
+    "item.playercontainer.basic_container": "Holdin' Bottle 'o Matey",
+    "item.playercontainer.large_container": "Holdin' Bottle 'o Three Musketeers",
+    "item.playercontainer.huge_container": "Holdin' Bottle 'o Crew",
+    "item.playercontainer.singularity_container": "Blackbeard's Bottomless Bottle o' Holdin n' Rum",
+    "item.playercontainer.loose_player": "Ol' Matey",
+    "item.playercontainer.loose_player.named": "%s",
+    "block.playercontainer.cage": "Wee Brig",
+    "item.playercontainer.self_container": "Me Own Holdin' Bottle",
+    "item.playercontainer.debug_container": "Ship Fixer's Testin' Bottle",
+    "item.playercontainer.player_essence": "Sailor Breath",
+    "item.playercontainer.player_essence.named": "%s's Breath",
+    "item.playercontainer.player_essence_bottle": "Bottle o' Sailor Breath",
+    "item.playercontainer.player_essence_bottle.named": "Bottle o' %s's Breath",
+
+    "itemGroup.playercontainer.playercontainer": "Scallywags in a Bottle",
+    
+    "tooltip.playercontainer.contains": "Holdin\':",
+    "tooltip.playercontainer.empty_fragile": "Aye, 'tis bottle here be damned! Breaks into a billion pieces when ye' hold it!",
+
+    "category.playercontainer": "Scallywags in a Bottle",
+    "key.playercontainer.release": "Release",
+
+    "gamerule.playercontainer:restrictToBooth": "Only permit scallywag activities in set area"
+}

--- a/src/main/resources/assets/playercontainer/lang/en_ud.json
+++ b/src/main/resources/assets/playercontainer/lang/en_ud.json
@@ -1,0 +1,25 @@
+{
+    "item.playercontainer.basic_container": "\u0279\u01DDu\u1D09\u0250\u0287uo\u0186 \u0254\u1D09s\u0250\u15FA",
+    "item.playercontainer.large_container": "\u0279\u01DDu\u1D09\u0250\u0287uo\u0186 \u01DD\u1D77\u0279\u0250\uA780",
+    "item.playercontainer.huge_container": "\u0279\u01DDu\u1D09\u0250\u0287uo\u0186 \u01DD\u1D77nH",
+    "item.playercontainer.singularity_container": "\u0279\u01DDu\u1D09\u0250\u0287uo\u0186 \u028E\u0287\u1D09\u0279\u0250\uA781n\u1D77u\u1D09S",
+    "item.playercontainer.loose_player": "\u0279\u01DD\u028E\u0250\uA781\u0500 \u01DDsoo\uA780",
+    "item.playercontainer.loose_player.named": "%s",
+    "block.playercontainer.cage": "\u01DD\u1D77\u0250\u0186 \u0279\u01DD\u028E\u0250\uA781\u0500",
+    "item.playercontainer.self_container": "\u0279\u01DDu\u1D09\u0250\u0287uo\u0186 \u025F\uA781\u01DDS",
+    "item.playercontainer.debug_container": "\u0279\u01DDu\u1D09\u0250\u0287uo\u0186 \u1D77nq\u01DD\u15E1",
+    "item.playercontainer.player_essence": "\u01DD\u0254u\u01DDss\u018E \u0279\u01DD\u028E\u0250\uA781\u0500",
+    "item.playercontainer.player_essence.named": "\u01DD\u0254u\u01DDss\u018E \u0279\u01DD\u028E\u0250\uA781\u0500 s,%s",
+    "item.playercontainer.player_essence_bottle": "\u01DD\u0254u\u01DDss\u018E \u0279\u01DD\u028E\u0250\uA781\u0500 \u025Fo \u01DD\uA781\u0287\u0287o\u15FA",
+    "item.playercontainer.player_essence_bottle.named": "\u01DD\u0254u\u01DDss\u018E s,%s \u025Fo \u01DD\uA781\u0287\u0287o\u15FA",
+
+    "itemGroup.playercontainer.playercontainer": "s\u0279\u01DDu\u1D09\u0250\u0287uo\u0186 \u0279\u01DD\u028E\u0250\uA781\u0500",
+    
+    "tooltip.playercontainer.contains": "su\u1D09\u0250\u0287uo\u0186 :",
+    "tooltip.playercontainer.empty_fragile": "\u00A1\u028E\u0279o\u0287u\u01DD\u028Cu\u1D09 s,\u0279\u01DD\u028E\u0250\uA781d \u0250 o\u0287 p\u01DD\u028Co\u026F u\u01DD\u0265\u028D p\u01DD\u028Eo\u0279\u0287s\u01DDp \u01DDq \uA781\uA781\u1D09M \u00A1\u0279\u01DDu\u1D09\u0250\u0287uo\u0254 \u01DD\uA781\u1D09\u1D77\u0250\u0279\u025F \u028E\u0287d\u026F\u018E",
+
+    "category.playercontainer": "s\u0279\u01DDu\u1D09\u0250\u0287uo\u0186 \u0279\u01DD\u028E\u0250\uA781\u0500",
+    "key.playercontainer.release": "\u01DDs\u0250\u01DD\uA781\u01DD\u1D1A",
+
+    "gamerule.playercontainer:restrictToBooth": "s\u0250\u01DD\u0279\u0250 \u0287\u01DDs u\u1D09 s\u0279\u01DDu\u1D09\u0250\u0287uo\u0254 \u0279\u01DD\u028E\u0250\uA781d \u028Do\uA781\uA781\u0250 \u028E\uA781uO"
+}

--- a/src/main/resources/assets/playercontainer/lang/enws.json
+++ b/src/main/resources/assets/playercontainer/lang/enws.json
@@ -1,0 +1,25 @@
+{
+    "item.playercontainer.basic_container": "Simple Vessel",
+    "item.playercontainer.large_container": "Vast Veseel",
+    "item.playercontainer.huge_container": "Collossal Vessel",
+    "item.playercontainer.singularity_container": "Vessel of the Dark Maw",
+    "item.playercontainer.loose_player": "Lax Player",
+    "item.playercontainer.loose_player.named": "%s",
+    "block.playercontainer.cage": "Prison of Man",
+    "item.playercontainer.self_container": "Vessel for Thyself",
+    "item.playercontainer.debug_container": "Vessel of Curiosity",
+    "item.playercontainer.player_essence": "Essence of Player",
+    "item.playercontainer.player_essence.named": "Essence of %s",
+    "item.playercontainer.player_essence_bottle": "Phial of Essence",
+    "item.playercontainer.player_essence_bottle.named": "Phial of the Essence of %s",
+
+    "itemGroup.playercontainer.playercontainer": "Player Vessels",
+    
+    "tooltip.playercontainer.contains": "Holdeth:",
+    "tooltip.playercontainer.empty_fragile": "Prithee! This vessel bears a frail shell, hollow! If thou is placed upon thy inventory, it shall breaketh!",
+
+    "category.playercontainer": "Player Vessels",
+    "key.playercontainer.release": "Unbind",
+
+    "gamerule.playercontainer:restrictToBooth": "Permit vessels only within ordained bounds"
+}

--- a/src/main/resources/assets/playercontainer/lang/lol_us.json
+++ b/src/main/resources/assets/playercontainer/lang/lol_us.json
@@ -1,0 +1,25 @@
+{
+    "item.playercontainer.basic_container": "lonelyy kitteh boxsr",
+    "item.playercontainer.large_container": "swag kittehz boxsr!!!",
+    "item.playercontainer.huge_container": "fam squadz kitteh boxsr!!!!!",
+    "item.playercontainer.singularity_container": "INFIUNT KITNAPZ!1!!",
+    "item.playercontainer.loose_player": "fren! :D",
+    "item.playercontainer.loose_player.named": "%s! :D",
+    "block.playercontainer.cage": "Kitteh Jeil!!",
+    "item.playercontainer.self_container": "HALP plz i trolp mslef :c",
+    "item.playercontainer.debug_container": "idk wha tezzdin boxr?? lmao",
+    "item.playercontainer.player_essence": "luv bean :3",
+    "item.playercontainer.player_essence.named": "%s's luv bean :3",
+    "item.playercontainer.player_essence_bottle": "luv bean potion :3",
+    "item.playercontainer.player_essence_bottle.named": "Poshun wif %s's luv bean :3",
+
+    "itemGroup.playercontainer.playercontainer": "Kitteh boxzrz",
+    
+    "tooltip.playercontainer.contains": "HAZ:",
+    "tooltip.playercontainer.empty_fragile": "MT bokxzr shensituv!!! go BYE BYE in teh fur Pouch :(",
+
+    "category.playercontainer": "kitteh boxzrz",
+    "key.playercontainer.release": "goh free!!!",
+
+    "gamerule.playercontainer:restrictToBooth": "kitteh boxzr exklusiv in ze arealib lmao"
+}


### PR DESCRIPTION
Felt silly x3

Decided to try my best to add language support for the joke languages, LOLCAT (lol_us), Upside Down (en_ud), Pirate Speak (en_pt), and Shakespearean English (enws).